### PR TITLE
Fix $0.00 Pricing in Cart Summary

### DIFF
--- a/app/controllers/workarea/storefront/cart_bulk_items_controller.rb
+++ b/app/controllers/workarea/storefront/cart_bulk_items_controller.rb
@@ -17,7 +17,7 @@ module Workarea
 
           @cart = CartViewModel.new(current_order, view_model_options)
           @items = add_to_cart.items.map do |cart_item|
-            OrderItemViewModel.wrap(cart_item.item, view_model_options)
+            OrderItemViewModel.wrap(cart_item.item.reload, view_model_options)
           end
         else
           flash[:error] =

--- a/test/system/workarea/storefront/product_variant_list_system_test.rb
+++ b/test/system/workarea/storefront/product_variant_list_system_test.rb
@@ -22,6 +22,7 @@ module Workarea
         click_button 'add_to_cart'
 
         assert(page.has_content?('Success'))
+        assert_text('$15.00')
 
         visit storefront.cart_path
         assert(page.has_content?(product.name))


### PR DESCRIPTION
Workarea now reloads the item data before rendering the cart summary so as to display the correct pricing for a variant list product.