### PR TITLE
Add Incompatibilities To README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,32 @@ cd path/to/application
 bundle
 ```
 
+Caveats
+--------------------------------------------------------------------------------
+
+The list of plugins that this template is known to be incompatible with
+includes, but not limited to:
+
+- [BOPUS](https://plugins.workarea.com/plugins/bopus)
+- [Subscriptions](https://plugins.workarea.com/plugins/subscriptions)
+- [Product Bundles](https://plugins.workarea.com/plugins/product-bundles)
+- [Wish Lists](https://plugins.workarea.com/plugins/wish-lists)
+
+In the case that you have a plugin installed that is not compatible with
+Variant Lists, you'll need to determine how the plugin is meant to
+interact with products on a variant list template. On most projects,
+you'll probably want to disable the interaction between the two plugins.
+For example, here's how you'd disable adding to wish list on variant
+list product templates by overriding **app/views/workarea/storefront/products/_add_to_wish_list.html.haml**:
+
+```haml
+- unless product.template == 'variant_list'
+    .wish-list-button
+      - if product.purchasable?
+        = link_to users_wish_list_path, class: 'wish-list-button__link text-button', data: { wish_list_button: '', analytics: add_to_wish_list_analytics_data(product).to_json } do
+          = t('workarea.storefront.wish_lists.add_to_wish_list')
+```
+
 Workarea Commerce Documentation
 --------------------------------------------------------------------------------
 


### PR DESCRIPTION
The variant list plugin is incompatible with several of Workarea's other plugins out-of-box. Add notes that document this and include an example of how one might use an incompatible plugin in the same project.

(this is a first draft, let me know if i should add anything)